### PR TITLE
Get working on Windows

### DIFF
--- a/app/controllers/directory.js
+++ b/app/controllers/directory.js
@@ -117,7 +117,7 @@ function init(){
 
 			 var sectionHeader = Ti.UI.createView({
 			 	backgroundColor: "#ececec",
-			 	width: Ti.UI.FIll,
+			 	width: Ti.UI.FILL,
 			 	height: 30
 			 });
 
@@ -260,7 +260,7 @@ var preprocessForListView = function(rawData) {
 		return {
 			template: isBookmark ? "favoriteTemplate" : "userTemplate",
 			properties: {
-				searchableText: item.name + ' ' + item.company + ' ' + item.email,
+				searchableText: item.firstName + ' ' + item.lastName + ' ' + item.company + ' ' + item.email,
 				user: item,
 			},
 			userName: {text: item.firstName+" "+item.lastName},

--- a/app/styles/directory.tss
+++ b/app/styles/directory.tss
@@ -81,7 +81,7 @@
 	showBookmark:true
 },
 
-".icon-search[platform=android]":{
+".icon-search[platform=android,windows]":{
 	font:{
 		fontFamily:"icomoon",
 		fontSize:24,
@@ -91,7 +91,7 @@
 	width:"7%",
 },
 
-".icon-close[platform=android]":{
+".icon-close[platform=android,windows]":{
 	font:{
 		fontFamily:"icomoon",
 		fontSize:24,
@@ -103,7 +103,7 @@
 	visible: false
 },
 
-"#searchBar[platform=android]":{
+"#searchBar[platform=android,windows]":{
 	height: 40,
 	left: 10,
 	width: "76%"

--- a/app/views/index.xml
+++ b/app/views/index.xml
@@ -1,6 +1,6 @@
 <Alloy>
 	<!-- Default App Window -->
-	<Require id="index" src="directory" platform="android" /> 
+	<Require id="index" src="directory" platform="android,windows" /> 
 	
     <!-- iOS Window -->
     <NavigationWindow id="nav" platform="ios" class="container">

--- a/app/views/profile.xml
+++ b/app/views/profile.xml
@@ -22,7 +22,7 @@
 					Map View 
 					Leverages the Map Module, allowing for v2 of Google Maps and latest codebase unifying Google v2 and IOS
 				-->
-				<Module id="mapview" module="ti.map" method="createView" platform="android,ios" class='no-touch top' />
+				<Module id="mapview" module="ti.map" method="createView" platform="android,ios,windows" class='no-touch top' />
 				<View ns="Ti.Map" id="mapview" platform="mobileweb" class='buffer border-dark-thick no-touch top' />
 			
 			

--- a/tiapp.xml
+++ b/tiapp.xml
@@ -13,6 +13,7 @@
     <analytics>true</analytics>
     <guid>11111111-1111-1111-1111-111111111111</guid>
     <property name="ti.ui.defaultunit" type="string">dp</property>
+    <property name="ti.windows.publishername" type="string">CN=Appcelerator Inc.</property>
     <ios>
         <plist>
             <dict>
@@ -55,8 +56,7 @@
         <manifest>
             <application android:theme="@style/appcelerator">
                 <!-- Replace "PASTE YOUR GOOGLE MAPS API KEY HERE" with the Google API key you obtained -->
-                <meta-data
-                    android:name="com.google.android.maps.v2.API_KEY" android:value="AIzaSyACkaMjxhKbemYoBxMM4g05FSIPv-_59kg"/>
+                <meta-data android:name="com.google.android.maps.v2.API_KEY" android:value="AIzaSyACkaMjxhKbemYoBxMM4g05FSIPv-_59kg"/>
             </application>
             <uses-sdk android:minSdkVersion="14"/>
             <uses-sdk android:targetSdkVersion="21"/>
@@ -72,8 +72,7 @@
             <uses-permission android:name="com.google.android.providers.gsf.permission.READ_GSERVICES"/>
             <uses-feature android:glEsVersion="0x00020000" android:required="true"/>
             <uses-permission android:name="com.appcelerator.directory.permission.MAPS_RECEIVE"/>
-            <permission
-                android:name="com.appcelerator.directory.permission.MAPS_RECEIVE" android:protectionLevel="signature"/>
+            <permission android:name="com.appcelerator.directory.permission.MAPS_RECEIVE" android:protectionLevel="signature"/>
         </manifest>
     </android>
     <mobileweb>
@@ -84,17 +83,26 @@
         </splash>
         <theme>default</theme>
     </mobileweb>
+    <windows>
+        <manifest>
+            <Capabilities>
+                <Capability Name="internetClient"/>
+                <DeviceCapability Name="location"/>
+            </Capabilities>
+        </manifest>
+    </windows>
     <modules>
         <module platform="android">ti.map</module>
         <module platform="iphone">ti.map</module>
     </modules>
     <deployment-targets>
+        <target device="windows">true</target>
         <target device="android">true</target>
         <target device="ipad">false</target>
         <target device="iphone">true</target>
         <target device="mobileweb">true</target>
     </deployment-targets>
-    <sdk-version>4.0.0.GA</sdk-version>
+    <sdk-version>4.1.0.GA</sdk-version>
     <plugins>
         <plugin version="1.0">ti.alloy</plugin>
     </plugins>


### PR DESCRIPTION
The searchbar doesn't exist on Windows. My first attempt to add it back looked OK visually, but crashed the app as soon as I started entering text, which likely means we've introduced some bug in the filtering recently (cc @infosia - Maybe from https://jira.appcelerator.org/browse/TIMOB-19085 )
